### PR TITLE
Issue #24 Add wrapper for CFPropertyList

### DIFF
--- a/classes/property_list.php
+++ b/classes/property_list.php
@@ -104,13 +104,13 @@ class property_list {
      * Only allow string, number and boolean elements to be updated.
      *
      * @param string $key Key of element to update.
-     * @param mixed $value  Value to update element with.
+     * @param mixed $value Value to update element with.
+     *
+     * @throws \invalid_parameter_exception
      */
     public function update_element_value(string $key, $value) {
         if (is_array($value)) {
-            debugging('property_list: Can\'t call update_element_value with array. Use update_element_array instead.',
-                    DEBUG_DEVELOPER);
-            return;
+            throw new \invalid_parameter_exception('Use update_element_array to update a collection.');
         }
         $this->plist_map( function($elvalue, $elkey, $parent) use ($key, $value) {
             // Set new value.
@@ -122,9 +122,9 @@ class property_list {
                         || ($element instanceof CFBoolean && is_bool($value))) {
                     $element->setValue($value);
                 } else {
-                    debugging('property_list: Can only update strings, numbers and bools with corresponding type.',
-                        DEBUG_DEVELOPER);
-                    return;
+                    throw new \invalid_parameter_exception(
+                            'Only string, number and boolean elements can be updated, or value type does not match element type: '
+                            . get_class($element));
                 }
             }
         }, $this->cfpropertylist->getValue());
@@ -136,16 +136,16 @@ class property_list {
      * Will replace array.
      *
      * @param string $key Key of element to update.
-     * @param array $value  Array to update element with.
+     * @param array $value Array to update element with.
+     *
+     * @throws \invalid_parameter_exception
      */
     public function update_element_array(string $key, array $value) {
         // Validate new array.
         foreach ($value as $element) {
-            // If any element is not a CFType instance, then do nothing.
+            // If any element is not a CFType instance, then throw exception.
             if (!($element instanceof CFType)) {
-                debugging('property_list: If updating an array in PList, it must only contain CFType objects.',
-                    DEBUG_DEVELOPER);
-                return;
+                throw new \invalid_parameter_exception('New array must only contain CFType objects.');
             }
         }
         $this->plist_map( function($elvalue, $elkey, $parent) use ($key, $value) {

--- a/classes/property_list.php
+++ b/classes/property_list.php
@@ -143,6 +143,8 @@ class property_list {
         foreach ($value as $element) {
             // If any element is not a CFType instance, then do nothing.
             if (!($element instanceof CFType)) {
+                debugging('property_list: If updating an array in PList, it must only contain CFType objects.',
+                    DEBUG_DEVELOPER);
                 return;
             }
         }

--- a/classes/property_list.php
+++ b/classes/property_list.php
@@ -1,0 +1,295 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Wrapper for CFPropertyList to handle low level iteration.
+ *
+ * @package    quizaccess_seb
+ * @author     Andrew Madden <andrewmadden@catalyst-au.net>
+ * @copyright  2019 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace quizaccess_seb;
+
+use CFPropertyList\CFArray;
+use CFPropertyList\CFData;
+use CFPropertyList\CFDate;
+use CFPropertyList\CFDictionary;
+use CFPropertyList\CFPropertyList;
+use CFPropertyList\CFString;
+use CFPropertyList\CFType;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . '/../vendor/autoload.php');
+
+class property_list {
+
+    /** @var CFPropertyList $cfpropertylist */
+    private $cfpropertylist;
+
+    /**
+     * property_list constructor.
+     *
+     * @param string $xml A Plist XML string.
+     *
+     * @throws \CFPropertyList\IOException
+     * @throws \CFPropertyList\PListException
+     * @throws \DOMException
+     */
+    public function __construct(string $xml) {
+        $this->cfpropertylist = new CFPropertyList();
+        $this->cfpropertylist->parse($xml, CFPropertyList::FORMAT_XML);
+    }
+
+    /**
+     * Create an empty property list.
+     *
+     * @return property_list Return a property list with a empty root dictionary set up.
+     *
+     * @throws \CFPropertyList\IOException
+     * @throws \CFPropertyList\PListException
+     * @throws \DOMException
+     */
+    public static function create() {
+        $cfpropertylist = new CFPropertyList();
+        // Add main dict.
+        $cfpropertylist->add(new CFDictionary([]));
+        return new self($cfpropertylist->toXML());
+    }
+
+    /**
+     * Add a new element to the root dictionary element.
+     *
+     * @param string $key Key to assign to new element.
+     * @param CFType $element The new element. May be a collection such as an array.
+     */
+    public function add_element_to_root(string $key, CFType $element) {
+        // Get the PList's root dictionary and add new element.
+        $this->cfpropertylist->getValue()->add($key, $element);
+    }
+
+    /**
+     * Get value of element identified by key.
+     *
+     * @param string $key Key of element.
+     * @return mixed Value of element found, or null if none found.
+     */
+    public function get_element_value(string $key) {
+        $result = null;
+        $this->plist_map( function($elvalue, $elkey, $parent) use ($key, &$result) {
+            // Convert date to iso 8601 if date object.
+            if ($key === $elkey) {
+                $result = $elvalue->getValue();
+            }
+        }, $this->cfpropertylist->getValue());
+        // Turn PList dicts and arrays into PHP array for export.
+        if (is_array($result)) {
+            $result = new CFDictionary($result); // Convert back to CFDictionary so serialization is recursive.
+            $result = $result->toArray(); // Serialize.
+        }
+        return $result;
+    }
+
+    /**
+     * Update the value of any element with matching key.
+     *
+     * @param string $key Key of element to update.
+     * @param mixed $value  Value to update element with.
+     */
+    public function update_element_value(string $key, $value) {
+        $this->plist_map( function($elvalue, $elkey, $parent) use ($key, $value) {
+            // Set new value.
+            if ($key === $elkey) {
+                $parent->get($elkey)->setValue($value);
+            }
+        }, $this->cfpropertylist->getValue());
+    }
+
+    /**
+     * Update the array of any dict or array element with matching key.
+     *
+     * Will replace array.
+     *
+     * @param string $key Key of element to update.
+     * @param array $value  Array to update element with.
+     */
+    public function update_element_array(string $key, array $value) {
+        $this->plist_map( function($elvalue, $elkey, $parent) use ($key, $value) {
+            if ($key === $elkey) {
+                $element = $parent->get($elkey);
+                // Replace existing element with new element and array but same key.
+                if ($element instanceof CFDictionary) {
+                    $parent->del($elkey);
+                    $parent->add($elkey, new CFDictionary($value));
+                } else if ($element instanceof CFArray) {
+                    $parent->del($elkey);
+                    $parent->add($elkey, new CFArray($value));
+                }
+            }
+        }, $this->cfpropertylist->getValue());
+    }
+
+    /**
+     * Delete any element with a matching key.
+     *
+     * @param string $key Key of element to delete.
+     */
+    public function delete_element(string $key) {
+        $this->plist_map( function($elvalue, $elkey, $parent) use ($key) {
+            // Convert date to iso 8601 if date object.
+            if ($key === $elkey) {
+                $parent->del($key);
+            }
+        }, $this->cfpropertylist->getValue());
+    }
+
+    /**
+     * Convert the PList to XML.
+     *
+     * @return string XML ready for creating an XML file.
+     */
+    public function to_xml() : string {
+        return $this->cfpropertylist->toXML();
+    }
+
+    /**
+     * Return a JSON representation of the PList. The JSON is constructed to be used to generate a SEB Config Key.
+     *
+     * See the developer documention for SEB for more information on the requirements on generating a SEB Config Key.
+     * https://safeexambrowser.org/developer/seb-config-key.html
+     *
+     * @return string A json encoded string.
+     */
+    public function to_json() : string {
+        // Create a clone of the PList, so main list isn't mutated.
+        $jsonplist = new CFPropertyList();
+        $jsonplist->parse($this->cfpropertylist->toXML(), CFPropertyList::FORMAT_XML);
+
+        // Pass root dict to recursively convert dates to ISO 8601 format, encode strings to UTF-8
+        // and lock data to Base 64 encoding.
+        $this->encode_dates_and_strings($jsonplist->getValue());
+
+        // Serialize PList to array.
+        $array = $jsonplist->toArray();
+
+        // Remove empty arrays.
+        $array = $this->array_remove_empty_arrays($array);
+
+        // Sort alphabetically.
+        $array = $this->array_sort($array);
+
+        // Encode in JSON with following rules from SEB docs.
+        // 1. Don't add any whitespace or line formatting to the SEB-JSON string.
+        // 2. Don't add character escaping.
+        return json_encode($array, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+    }
+
+    /**
+     * Recursively convert PList date values from unix to iso 8601 format, and ensure strings are UTF 8 encoded.
+     *
+     * This will mutate the PList.
+     */
+    private function encode_dates_and_strings($root) {
+        $this->plist_map( function($value, $key, $parent) {
+            // Convert date to iso 8601 if date object.
+            if ($value instanceof CFDate) {
+                $value->setValue(date('c', $value->getValue()));
+            }
+            // Make sure strings are UTF 8 encoded.
+            if ($value instanceof CFString) {
+                $value->setValue(mb_convert_encoding($value->getValue(), 'UTF-8'));
+            }
+            // Data should remain base 64 encoded, so convert to base encoded string for export. Otherwise
+            // CFData will decode the data when serialized.
+            if ($value instanceof CFData) {
+                $data = $value->getCodedValue();
+                $parent->del($key);
+                $parent->add($key, new CFString($data));
+            }
+        }, $root);
+
+    }
+
+    /**
+     * Iterate through the PList elements, and call the callback on each.
+     *
+     * @param callable $callback A callback function called for every element.
+     * @param \Iterator $root The root element of the PList. Must be a dictionary or array.
+     * @param bool $recursive Whether the function should traverse dicts and arrays recursively.
+     */
+    private function plist_map(callable $callback, \Iterator $root, bool $recursive = true) {
+        $root->rewind();
+        while ($root->valid()) {
+            $value = $root->current();
+            $key = $root->key();
+
+            // Recursively traverse all dicts and arrays if flag is true.
+            if ($recursive && $value instanceof \Iterator) {
+                $this->plist_map($callback, $value);
+            }
+
+            // Callback function called for every element.
+            //
+            // @param mixed $value Value of current element.
+            // @param string $key Key of element.
+            // @param CFType $parent Parent of element.
+            $callback($value, $key, $root);
+
+            $root->next();
+        }
+    }
+
+    /**
+     * Recursively sort array alphabetically by key.
+     *
+     * @param array $array Top level array to process.
+     * @return array Processed array.
+     */
+    private function array_sort(array $array) {
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                $array[$key] = $this->array_sort($array[$key]);
+            }
+        }
+        // Sort array. From SEB docs - "Use non-localized (culture invariant), non-ASCII value based case insensitive ordering."
+        ksort($array, SORT_NATURAL | SORT_FLAG_CASE);
+
+        return $array;
+    }
+
+    /**
+     * Recursively remove empty arrays.
+     *
+     * @param array $array Top level array to process.
+     * @return array Processed array.
+     */
+    private function array_remove_empty_arrays(array $array) {
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                $array[$key] = $this->array_remove_empty_arrays($array[$key]);
+            }
+
+            // Remove empty arrays.
+            if (is_array($array[$key]) && empty($array[$key])) {
+                unset($array[$key]);
+            }
+        }
+
+        return $array;
+    }
+}

--- a/tests/phpunit/property_list_test.php
+++ b/tests/phpunit/property_list_test.php
@@ -253,34 +253,45 @@ class quizaccess_seb_property_list_testcase extends advanced_testcase {
 
         return [
             'Update string with bool' => ['<key>testKey</key><string>testValue</string>', 'testKey', true, 'testValue',
-                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, or value type does not match element type: CFPropertyList\CFString'],
+                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, '
+                    . 'or value type does not match element type: CFPropertyList\CFString'],
             'Update string with number' => ['<key>testKey</key><string>testValue</string>', 'testKey', 999, 'testValue',
-                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, or value type does not match element type: CFPropertyList\CFString'],
+                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, '
+                    . 'or value type does not match element type: CFPropertyList\CFString'],
             'Update string with null' => ['<key>testKey</key><string>testValue</string>', 'testKey', null, 'testValue',
-                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, or value type does not match element type: CFPropertyList\CFString'],
+                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, '
+                    . 'or value type does not match element type: CFPropertyList\CFString'],
             'Update string with array' => ['<key>testKey</key><string>testValue</string>', 'testKey', ['arrayValue'], 'testValue',
                     'Use update_element_array to update a collection.'],
             'Update bool with string' => ['<key>testKey</key><true/>', 'testKey', 'testValue', true,
-                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, or value type does not match element type: CFPropertyList\CFBool'],
+                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, '
+                    . 'or value type does not match element type: CFPropertyList\CFBool'],
             'Update bool with number' => ['<key>testKey</key><true/>', 'testKey', 999, true,
-                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, or value type does not match element type: CFPropertyList\CFBool'],
+                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, '
+                    . 'or value type does not match element type: CFPropertyList\CFBool'],
             'Update bool with null' => ['<key>testKey</key><true/>', 'testKey', null, true,
-                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, or value type does not match element type: CFPropertyList\CFBool'],
+                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, '
+                    . 'or value type does not match element type: CFPropertyList\CFBool'],
             'Update bool with array' => ['<key>testKey</key><true/>', 'testKey', ['testValue'], true,
                     'Use update_element_array to update a collection.'],
             'Update number with string' => ['<key>testKey</key><real>888</real>', 'testKey', 'string', 888,
-                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, or value type does not match element type: CFPropertyList\CFNumber'],
+                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, '
+                    . 'or value type does not match element type: CFPropertyList\CFNumber'],
             'Update number with bool' => ['<key>testKey</key><real>888</real>', 'testKey', true, 888,
-                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, or value type does not match element type: CFPropertyList\CFNumber'],
+                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, '
+                    . 'or value type does not match element type: CFPropertyList\CFNumber'],
             'Update number with null' => ['<key>testKey</key><real>888</real>', 'testKey', null, 888,
-                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, or value type does not match element type: CFPropertyList\CFNumber'],
+                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, '
+                    . 'or value type does not match element type: CFPropertyList\CFNumber'],
             'Update number with array' => ['<key>testKey</key><real>888</real>', 'testKey', ['testValue'], 888,
                     'Use update_element_array to update a collection.'],
             'Update date with string' => ['<key>testKey</key><date>1940-10-09T22:13:56Z</date>', 'testKey', 'string',
                     '1940-10-10T06:13:56+08:00',
-                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, or value type does not match element type: CFPropertyList\CFDate'],
+                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, '
+                    . 'or value type does not match element type: CFPropertyList\CFDate'],
             'Update data with number' => ['<key>testKey</key><data>testData</data>', 'testKey', 789, 'testData',
-                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, or value type does not match element type: CFPropertyList\CFData'],
+                    'Invalid parameter value detected (Only string, number and boolean elements can be updated, '
+                    . 'or value type does not match element type: CFPropertyList\CFData'],
         ];
     }
 

--- a/tests/phpunit/property_list_test.php
+++ b/tests/phpunit/property_list_test.php
@@ -163,6 +163,8 @@ class quizaccess_seb_property_list_testcase extends advanced_testcase {
         $plist = new property_list($xml);
         $plist->update_element_array('testDict', [false]);
         $this->assertEquals(['testKey' => 'testValue'], $plist->get_element_value('testDict'));
+        $this->assertDebuggingCalled('property_list: If updating an array in PList, it must only contain CFType objects.',
+                DEBUG_DEVELOPER);
     }
 
     /**

--- a/tests/phpunit/property_list_test.php
+++ b/tests/phpunit/property_list_test.php
@@ -1,0 +1,222 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * PHPUnit for property_list class.
+ *
+ * @package    quizaccess_seb
+ * @author     Andrew Madden <andrewmadden@catalyst-au.net>
+ * @copyright  2019 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use quizaccess_seb\property_list;
+
+defined('MOODLE_INTERNAL') || die();
+
+class quizaccess_seb_property_list_testcase extends advanced_testcase {
+
+    /**
+     * Test that an empty PList with a root dictionary is created.
+     */
+    public function test_create_empty_plist() {
+        $emptyplist = property_list::create();
+        $xml = trim($emptyplist->to_xml());
+        $this->assertEquals('<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict/></plist>', $xml);
+    }
+
+    /**
+     * Test that a Plist is constructed from an XML string.
+     */
+    public function test_construct_plist_from_xml() {
+        $xml = $this->get_plist_xml_header()
+            . "<key>testKey</key>"
+            . "<string>testValue</string>"
+            . $this->get_plist_xml_footer();
+        $plist = new property_list($xml);
+        $generatedxml = trim($plist->to_xml());
+        $this->assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\"><dict><key>testKey</key><string>testValue</string></dict></plist>", $generatedxml);
+    }
+
+    /**
+     * Test that an element can be added to the root dictionary.
+     */
+    public function test_add_element_to_root() {
+        $plist = property_list::create();
+        $newelement = new \CFPropertyList\CFString('testValue');
+        $plist->add_element_to_root('testKey', $newelement);
+        $generatedxml = trim($plist->to_xml());
+        $this->assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\"><dict><key>testKey</key><string>testValue</string></dict></plist>", $generatedxml);
+    }
+
+    /**
+     * Test that an element's value can be retrieved.
+     */
+    public function test_get_element_value() {
+        $xml = $this->get_plist_xml_header()
+                . "<key>testKey</key>"
+                . "<string>testValue</string>"
+                . $this->get_plist_xml_footer();
+        $plist = new property_list($xml);
+        $this->assertEquals('testValue', $plist->get_element_value('testKey'));
+    }
+
+    /**
+     * Test an element's value can be retrieved if it is an array.
+     */
+    public function test_get_element_value_if_array() {
+        $xml = $this->get_plist_xml_header()
+            . "<key>testDict</key>"
+            . "<dict>"
+            . "<key>testKey</key>"
+            . "<string>testValue</string>"
+            . "</dict>"
+            . $this->get_plist_xml_footer();
+        $plist = new property_list($xml);
+        $this->assertEquals(['testKey' => 'testValue'], $plist->get_element_value('testDict'));
+    }
+
+    /**
+     * Test that a element's value can be updated that is not an array or dictionary.
+     */
+    public function test_updating_element_value() {
+        $xml = $this->get_plist_xml_header()
+            . "<key>testKey</key>"
+            . "<string>testValue</string>"
+            . $this->get_plist_xml_footer();
+        $plist = new property_list($xml);
+        $plist->update_element_value('testKey', 'newValue');
+        $this->assertEquals('newValue', $plist->get_element_value('testKey'));
+    }
+
+    /**
+     * Test that a dictionary can have it's value (array) updated.
+     */
+    public function test_updating_element_value_if_dictionary() {
+        $xml = $this->get_plist_xml_header()
+            . "<key>testDict</key>"
+            . "<dict>"
+            . "<key>testKey</key>"
+            . "<string>testValue</string>"
+            . "</dict>"
+            . $this->get_plist_xml_footer();
+        $plist = new property_list($xml);
+        $plist->update_element_array('testDict', ['newKey' => new \CFPropertyList\CFString('newValue')]);
+        $this->assertEquals(['newKey' => 'newValue'], $plist->get_element_value('testDict'));
+    }
+
+    /**
+     * Test that an element can be deleted.
+     */
+    public function test_delete_element() {
+        $xml = $this->get_plist_xml_header()
+            . "<key>testKey</key>"
+            . "<string>testValue</string>"
+            . $this->get_plist_xml_footer();
+        $plist = new property_list($xml);
+        $plist->delete_element('testKey');
+        $generatedxml = trim($plist->to_xml());
+        $this->assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\"><dict/></plist>", $generatedxml);
+    }
+
+    /**
+     * Test that json is exported correctly according to SEB Config Key requirements.
+     *
+     * @param string $xml PList XML used to generate CFPropertyList.
+     * @param string $expectedjson Expected JSON output.
+     *
+     * @dataProvider json_data_provider
+     */
+    public function test_export_to_json($xml, $expectedjson) {
+        $xml = $this->get_plist_xml_header()
+            . $xml
+            . $this->get_plist_xml_footer();
+        $plist = new property_list($xml);
+        $generatedjson = $plist->to_json();
+        $this->assertEquals($expectedjson, $generatedjson);
+    }
+
+    /**
+     * Get a valid PList header. Must also use footer.
+     *
+     * @return string
+     */
+    private function get_plist_xml_header() : string {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+                . "<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+                . "<plist version=\"1.0\">\n"
+                . "  <dict>";
+    }
+
+    /**
+     * Get a valid PList footer. Must also use header.
+     *
+     * @return string
+     */
+    private function get_plist_xml_footer() : string {
+        return "  </dict>\n"
+                . "</plist>";
+    }
+
+    /**
+     * Data provider for expected JSON from PList.
+     *
+     * Examples extracted from requirements listed in SEB Config Key documents.
+     * https://safeexambrowser.org/developer/seb-config-key.html
+     *
+     * 1. Date should be in ISO 8601 format.
+     * 2. Data should be base 64 encoded.
+     * 3. String should be UTF-8 encoded.
+     * 4, 5, 6. No requirements for bools, arrays or dicts.
+     * 7. Empty arrays should not be included.
+     * 8. JSON key ordering should be case insenstive, and use natural ordering.
+     * 9. URL forward slashes should not be escaped.
+     *
+     * @return array
+     */
+    public function json_data_provider() : array {
+        $data = "blahblah";
+        $base64data = base64_encode($data);
+
+        return [
+            'date' => ["<key>date</key><date>1940-10-09T22:13:56Z</date>", "{\"date\":\"1940-10-10T06:13:56+08:00\"}"],
+            'data' => ["<key>data</key><data>$base64data</data>", "{\"data\":\"$base64data\"}"],
+            'string' => ["<key>string</key><string>hello wörld</string>", "{\"string\":\"hello wörld\"}"],
+            'bool' => ["<key>bool</key><true/>", "{\"bool\":true}"],
+            'array' => ["<key>dict</key><array><key>dictbool</key><false/><key>dictbool2</key><true/></array>"
+                    , "{\"dict\":[false,true]}"],
+            'dict' => ["<key>dict</key><dict><key>dictbool</key><false/><key>dictbool2</key><true/></dict>"
+                    , "{\"dict\":{\"dictbool\":false,\"dictbool2\":true}}"],
+            'empty array' => ["<key>bool</key><true/><key>emptydict</key><dict/>", "{\"bool\":true}"],
+            'unordered elements' => ["<key>testKey</key>"
+                    . "<string>testValue</string>"
+                    . "<key>allowWLAN</key>"
+                    . "<string>testValue2</string>"
+                    . "<key>allowWlan</key>"
+                    . "<string>testValue3</string>"
+                    , "{\"allowWlan\":\"testValue3\",\"allowWLAN\":\"testValue2\",\"testKey\":\"testValue\"}"],
+            'url' => ["<key>url</key><string>http://test.com</string>", "{\"url\":\"http://test.com\"}"]
+        ];
+    }
+}

--- a/tests/phpunit/property_list_test.php
+++ b/tests/phpunit/property_list_test.php
@@ -33,7 +33,7 @@ class quizaccess_seb_property_list_testcase extends advanced_testcase {
      * Test that an empty PList with a root dictionary is created.
      */
     public function test_create_empty_plist() {
-        $emptyplist = property_list::create();
+        $emptyplist = new property_list();
         $xml = trim($emptyplist->to_xml());
         $this->assertEquals('<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -59,7 +59,7 @@ class quizaccess_seb_property_list_testcase extends advanced_testcase {
      * Test that an element can be added to the root dictionary.
      */
     public function test_add_element_to_root() {
-        $plist = property_list::create();
+        $plist = new property_list();
         $newelement = new \CFPropertyList\CFString('testValue');
         $plist->add_element_to_root('testKey', $newelement);
         $generatedxml = trim($plist->to_xml());
@@ -97,21 +97,46 @@ class quizaccess_seb_property_list_testcase extends advanced_testcase {
 
     /**
      * Test that a element's value can be updated that is not an array or dictionary.
+     *
+     * @param string $xml XML to create PList.
+     * @param string $key Key of element to try and update.
+     * @param mixed $value Value to try to update with.
+     *
+     * @dataProvider good_update_data_provider
      */
-    public function test_updating_element_value() {
+    public function test_updating_element_value($xml, $key, $value) {
         $xml = $this->get_plist_xml_header()
-            . "<key>testKey</key>"
-            . "<string>testValue</string>"
+            . $xml
             . $this->get_plist_xml_footer();
         $plist = new property_list($xml);
-        $plist->update_element_value('testKey', 'newValue');
-        $this->assertEquals('newValue', $plist->get_element_value('testKey'));
+        $plist->update_element_value($key, $value);
+        $this->assertEquals($value, $plist->get_element_value($key));
+    }
+
+    /**
+     * Test that a element's value can be updated that is not an array or dictionary.
+     *
+     * @param string $xml XML to create PList.
+     * @param string $key Key of element to try and update.
+     * @param mixed $value Bad value to try to update with.
+     * @param mixed $expected Expected value of element after update is called.
+     * @dataProvider bad_update_data_provider
+     */
+    public function test_updating_element_value_with_bad_data(string $xml, string $key, $value, $expected, $debugcount) {
+        $xml = $this->get_plist_xml_header()
+            . $xml
+            . $this->get_plist_xml_footer();
+        $plist = new property_list($xml);
+        $plist->update_element_value($key, $value);
+        $plistarray = json_decode($plist->to_json()); // Export elements.
+        $this->assertEquals($expected, $plistarray->$key);
+        $this->assertDebuggingCalledCount($debugcount);
     }
 
     /**
      * Test that a dictionary can have it's value (array) updated.
      */
-    public function test_updating_element_value_if_dictionary() {
+    public function test_updating_element_array_if_dictionary() {
         $xml = $this->get_plist_xml_header()
             . "<key>testDict</key>"
             . "<dict>"
@@ -122,6 +147,22 @@ class quizaccess_seb_property_list_testcase extends advanced_testcase {
         $plist = new property_list($xml);
         $plist->update_element_array('testDict', ['newKey' => new \CFPropertyList\CFString('newValue')]);
         $this->assertEquals(['newKey' => 'newValue'], $plist->get_element_value('testDict'));
+    }
+
+    /**
+     * Test that a dictionary can have it's value (array) updated.
+     */
+    public function test_updating_element_array_if_dictionary_with_bad_data() {
+        $xml = $this->get_plist_xml_header()
+            . "<key>testDict</key>"
+            . "<dict>"
+            . "<key>testKey</key>"
+            . "<string>testValue</string>"
+            . "</dict>"
+            . $this->get_plist_xml_footer();
+        $plist = new property_list($xml);
+        $plist->update_element_array('testDict', [false]);
+        $this->assertEquals(['testKey' => 'testValue'], $plist->get_element_value('testDict'));
     }
 
     /**
@@ -177,6 +218,46 @@ class quizaccess_seb_property_list_testcase extends advanced_testcase {
     private function get_plist_xml_footer() : string {
         return "  </dict>\n"
                 . "</plist>";
+    }
+
+    /**
+     * Data provider for good data on update.
+     *
+     * @return array Array with test data.
+     */
+    public function good_update_data_provider() : array {
+        return [
+            'Update string' => ['<key>testKey</key><string>testValue</string>', 'testKey', 'newValue'],
+            'Update bool' => ['<key>testKey</key><true/>', 'testKey', false],
+            'Update number' => ['<key>testKey</key><real>888</real>', 'testKey', 123.4],
+        ];
+    }
+
+    /**
+     * Data provider for bad data on update.
+     *
+     * @return array Array with test data.
+     */
+    public function bad_update_data_provider() : array {
+
+        return [
+            'Update string with bool' => ['<key>testKey</key><string>testValue</string>', 'testKey', true, 'testValue', 1],
+            'Update string with number' => ['<key>testKey</key><string>testValue</string>', 'testKey', 999, 'testValue', 1],
+            'Update string with null' => ['<key>testKey</key><string>testValue</string>', 'testKey', null, 'testValue', 1],
+            'Update string with array' => ['<key>testKey</key><string>testValue</string>', 'testKey', ['arrayValue'],
+                    'testValue', 1],
+            'Update bool with string' => ['<key>testKey</key><true/>', 'testKey', 'testValue', true, 1],
+            'Update bool with number' => ['<key>testKey</key><true/>', 'testKey', 999, true, 1],
+            'Update bool with null' => ['<key>testKey</key><true/>', 'testKey', null, true, 1],
+            'Update bool with array' => ['<key>testKey</key><true/>', 'testKey', ['testValue'], true, 1],
+            'Update number with string' => ['<key>testKey</key><real>888</real>', 'testKey', 'string', 888, 1],
+            'Update number with bool' => ['<key>testKey</key><real>888</real>', 'testKey', true, 888, 1],
+            'Update number with null' => ['<key>testKey</key><real>888</real>', 'testKey', null, 888, 1],
+            'Update number with array' => ['<key>testKey</key><real>888</real>', 'testKey', ['testValue'], 888, 1],
+            'Update date with string' => ['<key>testKey</key><date>1940-10-09T22:13:56Z</date>', 'testKey', 'string',
+                '1940-10-10T06:13:56+08:00', 1],
+            'Update data with number' => ['<key>testKey</key><data>testData</data>', 'testKey', 789, 'testData', 1],
+        ];
     }
 
     /**

--- a/tests/phpunit/sample_data/simpleunencrypted.seb
+++ b/tests/phpunit/sample_data/simpleunencrypted.seb
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>aaaaaa</key>
+    <date>1940-10-09T22:13:56Z</date>
+    <key>originatorVersion</key>
+    <string>SEB_Win_2.1.1</string>
+    <key>startURL</key>
+    <string>https://safeexambrowser.org/start</string>
+    <key>startResource</key>
+    <string />
+    <key>sebServerURL</key>
+    <string />
+    <key>hashedAdminPassword</key>
+    <string />
+    <key>allowQuit</key>
+    <true />
+    <key>ignoreExitKeys</key>
+    <true />
+    <key>allowUserAppFolderInstall</key>
+    <false />
+    <key>allowSiri</key>
+    <false />
+    <key>allowDictation</key>
+    <false />
+    <key>detectStoppedProcess</key>
+    <true />
+    <key>allowDisplayMirroring</key>
+    <false />
+    <key>allowedDisplaysMaxNumber</key>
+    <integer>1</integer>
+    <key>allowedDisplayBuiltin</key>
+    <true />
+  </dict>
+</plist>


### PR DESCRIPTION
Allow easier manipulation of config by abstracting iteration methods.
Added JSON export method in Config Key format ready for generating the hash.