### PR TITLE
Issue #6 Fix bug: Missing quiz id as quiz id is not a form setting.

### DIFF
--- a/rule.php
+++ b/rule.php
@@ -113,6 +113,8 @@ class quizaccess_seb extends quiz_access_rule_base {
 
         // Validate basic settings using persistent class.
         $quizsettings = (new quiz_settings())->from_record($settings);
+        // Set non-form fields.
+        $quizsettings->set('quizid', $data['instance']);
         $quizsettings->validate();
 
         // Add any errors to list.

--- a/tests/phpunit/rule_test.php
+++ b/tests/phpunit/rule_test.php
@@ -45,7 +45,7 @@ class quizaccess_seb_rule_testcase extends advanced_testcase {
     public function test_validate_settings_with_valid_data() {
         $form = $this->createMock('mod_quiz_mod_form');
         // Validate settings with a dummy form.
-        $errors = quizaccess_seb::validate_settings_form_fields([], ['seb_quizid' => 1], [],
+        $errors = quizaccess_seb::validate_settings_form_fields([], ['instance' => 1], [],
             $form);
         $this->assertEmpty($errors);
     }
@@ -55,9 +55,10 @@ class quizaccess_seb_rule_testcase extends advanced_testcase {
      */
     public function test_validate_settings_with_invalid_data() {
         $form = $this->createMock('mod_quiz_mod_form');
-        // Validate settings with a dummy form.
-        $errors = quizaccess_seb::validate_settings_form_fields([], [], [], $form);
-        $this->assertEquals(['seb_quizid' => 'Required field'], $errors);
+        // Validate settings with a dummy form and quiz instance.
+        $errors = quizaccess_seb::validate_settings_form_fields([],
+                ['instance' => 1, 'seb_requiresafeexambrowser' => 'Uh oh!'], [], $form);
+        $this->assertEquals(['seb_requiresafeexambrowser' => 'Data submitted is invalid'], $errors);
     }
 
     /**


### PR DESCRIPTION
Settings were not saving, because quiz id was missing when creating persistent object as they are not a standard setting.

Updated unit tests to cover this case.