### PR TITLE
Issue #20 Do not show individual quiz settings to users without capability

### DIFF
--- a/rule.php
+++ b/rule.php
@@ -89,6 +89,13 @@ class quizaccess_seb extends quiz_access_rule_base {
 
         // Insert all the form elements before the 'security' section as a group.
         foreach (settings_provider::get_quiz_element_types() as $name => $type) {
+            // Check capability of user.
+            if (!has_capability('quizaccess/seb:manage_' . $name, $quizform->get_context())) {
+                // Don't show the setting. If the setting has already been set, it will keep this state, otherwise it will
+                // be initialized with a default.
+                continue;
+            }
+
             // Create element.
             if (is_array($type)) {
                 $element = $mform->createElement($type[0], $name, get_string($name, 'quizaccess_seb'), $type[1]);

--- a/rule.php
+++ b/rule.php
@@ -89,11 +89,10 @@ class quizaccess_seb extends quiz_access_rule_base {
 
         // Insert all the form elements before the 'security' section as a group.
         foreach (settings_provider::get_quiz_element_types() as $name => $type) {
-            // Check capability of user.
+
+            // Check if the user has capability to edit setting, otherwise use hidden setting type.
             if (!has_capability('quizaccess/seb:manage_' . $name, $quizform->get_context())) {
-                // Don't show the setting. If the setting has already been set, it will keep this state, otherwise it will
-                // be initialized with a default.
-                continue;
+                $type = 'hidden'; // A disabled element may be more appropriate but does not currently exist.
             }
 
             // Create element.


### PR DESCRIPTION
I've asked a question to Telegram, about whether 'dependent' settings should be hidden as well. Presently, the individual setting capabilities are not dependent on anything else.