### PR TITLE
Issue #39 client config access rule

### DIFF
--- a/classes/access_manager.php
+++ b/classes/access_manager.php
@@ -150,6 +150,21 @@ class access_manager {
     }
 
     /**
+     * This is the basic check for the Safe Exam Browser previously used in the quizaccess_safebrowser plugin that
+     * managed basic Moodle interactions with SEB.
+     *
+     * @return bool
+     *
+     * @throws \coding_exception
+     */
+    public function validate_basic_header() : bool {
+        if ($this->quizsettings->get('requiresafeexambrowser') == settings_provider::USE_SEB_CLIENT_CONFIG) {
+            return strpos($_SERVER['HTTP_USER_AGENT'], 'SEB') !== false;
+        }
+        return true;
+    }
+
+    /**
      * Check if user has any capability to bypass the Safe Exam Browser requirement.
      *
      * @return bool True if user can bypass check.

--- a/classes/settings_provider.php
+++ b/classes/settings_provider.php
@@ -107,7 +107,7 @@ class settings_provider {
         // TODO: Implement following features and uncomment options.
         //$options[self::USE_SEB_TEMPLATE] = get_string('seb_use_template', 'quizaccess_seb');
         //$options[self::USE_SEB_UPLOAD_CONFIG] = get_string('seb_use_upload', 'quizaccess_seb');
-        //$options[self::USE_SEB_CLIENT_CONFIG] = get_string('seb_use_client', 'quizaccess_seb');
+        $options[self::USE_SEB_CLIENT_CONFIG] = get_string('seb_use_client', 'quizaccess_seb');
         // @codingStandardsIgnoreEnd
 
         return $options;

--- a/lang/en/quizaccess_seb.php
+++ b/lang/en/quizaccess_seb.php
@@ -107,6 +107,7 @@ $string['missingrequiredsettings'] = 'Config settings not provided all required 
 $string['noconfigfound'] = 'No SEB config could be found for quiz with cmid: {$a}';
 $string['allowedbrowserkeysdistinct'] = 'The keys must all be different.';
 $string['allowedbrowserkeyssyntax'] = 'A key should be a 64-character hex string.';
+$string['clientrequiresseb'] = 'This quiz has been configured to use the Safe Exam Browser with client configuration.';
 
 // Capabilities.
 $string['seb:bypassseb'] = 'Bypass the requirement to view quiz in Safe Exam Browser.';

--- a/rule.php
+++ b/rule.php
@@ -268,8 +268,11 @@ class quizaccess_seb extends quiz_access_rule_base {
      *      reason if access should be prevented.
      *
      * @throws coding_exception
+     * @throws moodle_exception
      */
     public function prevent_access() {
+        $quizsettings = quiz_settings::get_record(['quizid' => $this->quiz->id]);
+
         // If Safe Exam Browser is not required or user can bypass check, access to quiz should not be prevented.
         if (!$this->accessmanager->seb_required() || $this->accessmanager->can_bypass_seb()) {
             return false;
@@ -277,7 +280,7 @@ class quizaccess_seb extends quiz_access_rule_base {
 
         // If using client configuration, do basic check that user is using Safe Exam Browser in case no other access rules
         // apply.
-        if ($this->quiz->requiresafeexambrowser == settings_provider::USE_SEB_CLIENT_CONFIG
+        if ($quizsettings->get('requiresafeexambrowser') == settings_provider::USE_SEB_CLIENT_CONFIG
                 && !$this->accessmanager->validate_basic_header()) {
             // Return error message with download link.
             $errormessage = get_string('clientrequiresseb', 'quizaccess_seb')

--- a/rule.php
+++ b/rule.php
@@ -278,9 +278,10 @@ class quizaccess_seb extends quiz_access_rule_base {
             return false;
         }
 
-        // If using client configuration, do basic check that user is using Safe Exam Browser in case no other access rules
-        // apply.
+        // If using client configuration with no browser exam keys, do basic check that user is using Safe Exam Browser.
+        // It is more secure to use Browser Exam Keys than to rely on this check.
         if ($quizsettings->get('requiresafeexambrowser') == settings_provider::USE_SEB_CLIENT_CONFIG
+                && empty($quizsettings->get('allowedbrowserexamkeys'))
                 && !$this->accessmanager->validate_basic_header()) {
             // Return error message with download link.
             $errormessage = get_string('clientrequiresseb', 'quizaccess_seb')

--- a/rule.php
+++ b/rule.php
@@ -368,7 +368,10 @@ class quizaccess_seb extends quiz_access_rule_base {
         $buttons = '';
 
         $buttons .= html_writer::start_div();
-        $buttons .= $OUTPUT->single_button($this->get_seb_download_url(), get_string('sebdownloadbutton', 'quizaccess_seb'));
+        // If suppresssebdownloadlink setting is enabled, do not show download button.
+        if (empty($this->quiz->seb_suppresssebdownloadlink)) {
+            $buttons .= $OUTPUT->single_button($this->get_seb_download_url(), get_string('sebdownloadbutton', 'quizaccess_seb'));
+        }
         $buttons .= html_writer::end_div();
 
         return $buttons;

--- a/tests/phpunit/rule_test.php
+++ b/tests/phpunit/rule_test.php
@@ -111,8 +111,8 @@ class quizaccess_seb_rule_testcase extends quizaccess_seb_testcase {
         $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
 
         // Set quiz setting to require seb.
-        $quizsetting = \quizaccess_seb\quiz_settings::get_record(['quizid' => $quiz->id]);
-        $quizsetting->set('requiresafeexambrowser', 1);
+        $quizsetting = quiz_settings::get_record(['quizid' => $quiz->id]);
+        $quizsetting->set('requiresafeexambrowser', settings_provider::USE_SEB_CONFIG_MANUALLY);
         $quizsetting->save();
 
         $rule = new quizaccess_seb(new quiz($quiz, get_coursemodule_from_id('quiz', $quiz->cmid), $course), 0);
@@ -135,8 +135,8 @@ class quizaccess_seb_rule_testcase extends quizaccess_seb_testcase {
         $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
 
         // Set quiz setting to require seb.
-        $quizsettings = \quizaccess_seb\quiz_settings::get_record(['quizid' => $quiz->id]);
-        $quizsettings->set('requiresafeexambrowser', 1);
+        $quizsettings = quiz_settings::get_record(['quizid' => $quiz->id]);
+        $quizsettings->set('requiresafeexambrowser', settings_provider::USE_SEB_CONFIG_MANUALLY);
         $quizsettings->save();
 
         $configkey = $quizsettings->get('configkey');
@@ -177,6 +177,47 @@ class quizaccess_seb_rule_testcase extends quizaccess_seb_testcase {
     }
 
     /**
+     * Test access allowed if using client configuration and SEB user agent header is valid.
+     */
+    public function test_access_allowed_if_using_client_config_basic_header_is_valid() {
+        $course = $this->getDataGenerator()->create_course();
+        $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
+
+        // Set quiz setting to require seb.
+        $quizsettings = quiz_settings::get_record(['quizid' => $quiz->id]);
+        $quizsettings->set('requiresafeexambrowser', settings_provider::USE_SEB_CLIENT_CONFIG); // Doesn't check config key.
+        $quizsettings->save();
+
+        // Set up basic dummy request.
+        $_SERVER['HTTP_USER_AGENT'] = 'SEB_TEST_SITE';
+
+        $rule = new quizaccess_seb(new quiz($quiz, get_coursemodule_from_id('quiz', $quiz->cmid), $course), 0);
+        // Check that correct error message is returned.
+        $this->assertFalse($rule->prevent_access());
+    }
+
+    /**
+     * Test access prevented if using client configuration and SEB user agent header is invalid.
+     */
+    public function test_access_prevented_if_using_client_configuration_and_basic_head_is_invalid() {
+        $course = $this->getDataGenerator()->create_course();
+        $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
+
+        // Set quiz setting to require seb.
+        $quizsettings = quiz_settings::get_record(['quizid' => $quiz->id]);
+        $quizsettings->set('requiresafeexambrowser', settings_provider::USE_SEB_CLIENT_CONFIG); // Doesn't check config key.
+        $quizsettings->save();
+
+        // Set up basic dummy request.
+        $_SERVER['HTTP_USER_AGENT'] = 'WRONG_TEST_SITE';
+
+        $rule = new quizaccess_seb(new quiz($quiz, get_coursemodule_from_id('quiz', $quiz->cmid), $course), 0);
+        // Check that correct error message is returned.
+        $this->assertContains('This quiz has been configured to use the Safe Exam Browser with client configuration.',
+            $rule->prevent_access());
+    }
+
+    /**
      * Test access not prevented if SEB not required.
      */
     public function test_access_allowed_if_seb_not_required() {
@@ -184,8 +225,8 @@ class quizaccess_seb_rule_testcase extends quizaccess_seb_testcase {
         $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
 
         // Set quiz setting to not require seb.
-        $quizsettings = \quizaccess_seb\quiz_settings::get_record(['quizid' => $quiz->id]);
-        $quizsettings->set('requiresafeexambrowser', 0);
+        $quizsettings = quiz_settings::get_record(['quizid' => $quiz->id]);
+        $quizsettings->set('requiresafeexambrowser', settings_provider::USE_SEB_NO);
         $quizsettings->save();
 
         $rule = new quizaccess_seb(new quiz($quiz, get_coursemodule_from_id('quiz', $quiz->cmid), $course), 0);
@@ -201,8 +242,8 @@ class quizaccess_seb_rule_testcase extends quizaccess_seb_testcase {
         $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
 
         // Set quiz setting to require seb.
-        $quizsettings = \quizaccess_seb\quiz_settings::get_record(['quizid' => $quiz->id]);
-        $quizsettings->set('requiresafeexambrowser', 1);
+        $quizsettings = quiz_settings::get_record(['quizid' => $quiz->id]);
+        $quizsettings->set('requiresafeexambrowser', settings_provider::USE_SEB_CONFIG_MANUALLY);
         $quizsettings->save();
 
         // Set the bypass SEB check capability to $USER.

--- a/tests/phpunit/settings_provider_test.php
+++ b/tests/phpunit/settings_provider_test.php
@@ -90,12 +90,12 @@ class quizaccess_seb_settings_provider_testcase extends advanced_testcase {
      * Test SEB usage options.
      */
     public function test_get_requiresafeexambrowser_options() {
-        $this->assertCount(2, settings_provider::get_requiresafeexambrowser_options());
+        $this->assertCount(3, settings_provider::get_requiresafeexambrowser_options());
         $this->assertTrue(array_key_exists(0, settings_provider::get_requiresafeexambrowser_options()));
         $this->assertTrue(array_key_exists(1, settings_provider::get_requiresafeexambrowser_options()));
         $this->assertFalse(array_key_exists(2, settings_provider::get_requiresafeexambrowser_options()));
         $this->assertFalse(array_key_exists(3, settings_provider::get_requiresafeexambrowser_options()));
-        $this->assertFalse(array_key_exists(4, settings_provider::get_requiresafeexambrowser_options()));
+        $this->assertTrue(array_key_exists(4, settings_provider::get_requiresafeexambrowser_options()));
     }
 
     /**


### PR DESCRIPTION
* Add simple header check for USER_AGENT to contain SEB*
* Adjust access rule to check for user agent if using client config with no Browser Exam Keys.
* Add some tests to cover new access rule.

This code overlaps with adding in the browser exam key access rule PR #67 . 

May need some merge massaging if either this or the BEK PR is accepted first.