### PR TITLE
Format seb_requiresafeexambrowser_help even more.

### DIFF
--- a/lang/en/quizaccess_seb.php
+++ b/lang/en/quizaccess_seb.php
@@ -52,7 +52,7 @@ $string['seb_allowreloadinexam_help'] = 'If enabled, page reload is allowed (rel
 $string['seb_allowspellchecking'] = 'Enable spell checking';
 $string['seb_allowspellchecking_help'] = 'If enabled, spell checking in the SEB browser is allowed.';
 $string['seb_allowuserquitseb'] = 'Enable quitting of SEB';
-$string['seb_allowuserquitseb_help'] = 'If enabled, users can quit SEB with the “Quit” button in the SEB task bar or by pressing the keys Ctrl-Q or by clicking the main browser window close button.';
+$string['seb_allowuserquitseb_help'] = 'If enabled, users can quit SEB with the "Quit" button in the SEB task bar or by pressing the keys Ctrl-Q or by clicking the main browser window close button.';
 $string['seb_enableaudiocontrol'] = 'Enable audio controls';
 $string['seb_enableaudiocontrol_help'] = 'If enabled, the audio control icon is shown in the SEB task bar.';
 $string['seb_expressionsallowed'] = 'Expressions allowed';
@@ -62,11 +62,11 @@ $string['seb_expressionsblocked_help'] = 'A text field which contains the filter
 $string['seb_filterembeddedcontent'] = 'Filter also embedded content';
 $string['seb_filterembeddedcontent_help'] = 'If enabled, also all embedded resources will be filtered using the filter set.';
 $string['seb_linkquitseb'] = 'Show Exit Safe Exam Browser button, configured with this quit link';
-$string['seb_linkquitseb_help'] = 'In this field you can enter the link to quit SEB. It will be used on an “Exit Safe Exam Browser” button on the page that appears after the exam is submitted. When clicking the button or the link placed wherever you want to put it, it is possible to quit SEB without having to enter a quit password. If no link is entered, then the “Exit Safe Exam Browser” button does not appear and there is no link set to quit SEB.';
+$string['seb_linkquitseb_help'] = 'In this field you can enter the link to quit SEB. It will be used on an "Exit Safe Exam Browser" button on the page that appears after the exam is submitted. When clicking the button or the link placed wherever you want to put it, it is possible to quit SEB without having to enter a quit password. If no link is entered, then the "Exit Safe Exam Browser" button does not appear and there is no link set to quit SEB.';
 $string['seb_muteonstartup'] = 'Mute on startup';
 $string['seb_muteonstartup_help'] = 'If enabled, audio is initially muted when starting SEB.';
 $string['seb_quitpassword'] = 'Quit password';
-$string['seb_quitpassword_help'] = 'This password is prompted when users try to quit SEB with the ”Quit” button, Ctrl-Q or the close button in the main browser window. If no quit password is set, then SEB just prompts “Are you sure you want to quit SEB?”.';
+$string['seb_quitpassword_help'] = 'This password is prompted when users try to quit SEB with the "Quit" button, Ctrl-Q or the close button in the main browser window. If no quit password is set, then SEB just prompts "Are you sure you want to quit SEB?".';
 $string['seb_regexallowed'] = 'Regex allowed';
 $string['seb_regexallowed_help'] = 'A text field which contains the filtering expressions for allowed URLs in a regular expression (Regex) format.';
 $string['seb_regexblocked'] = 'Regex blocked';
@@ -75,11 +75,16 @@ $string['seb_requiresafeexambrowser'] = 'Require the use of Safe Exam Browser';
 $string['seb_requiresafeexambrowser_help'] = "If enabled, students can only attempt the quiz using the Safe Exam Browser.
 The available options are:
 
-* No – Safe Exam Browser is not required to attempt the quiz.
-* Yes - Use an existing template – A template for the configuration of Safe Exam Browser can be used. Templates are managed by the Moodle Administrator. Your manual settings overwrite the settings in the template.
-* Yes - Configure manually – No template for the configuration of Safe Exam Browser will be used. You can configure Safe Exam Browser manually.
-* Yes - Upload my own config – You can upload your own Safe Exam Browser configuration file. All manual settings and the use of templates will be disabled.
-* Yes - Use SEB client config – No configurations of Safe Exam Browser are on Moodle side. The quiz can be attempted with any configuration of Safe Exam Browser.";
+* No
+<br/>Safe Exam Browser is not required to attempt the quiz.
+* Yes – Use an existing template
+<br/>A template for the configuration of Safe Exam Browser can be used. Templates are managed by the Moodle Administrator. Your manual settings overwrite the settings in the template.
+* Yes – Configure manually
+<br/>No template for the configuration of Safe Exam Browser will be used. You can configure Safe Exam Browser manually.
+* Yes – Upload my own config
+<br/>You can upload your own Safe Exam Browser configuration file. All manual settings and the use of templates will be disabled.
+* Yes – Use SEB client config
+<br/>No configurations of Safe Exam Browser are on Moodle side. The quiz can be attempted with any configuration of Safe Exam Browser.";
 $string['seb_sebconfigtemplate'] = 'Safe Exam Browser config template';
 $string['seb_sebconfigtemplate_help'] = 'The settings in the selected config template will be used for the configuration of the Safe Exam Browser while attempting the quiz. You may overwrite the settings in the template with your manual settings.';
 $string['seb_showkeyboardlayout'] = 'Show keyboard layout';
@@ -98,10 +103,10 @@ $string['seb_sebconfigfile'] = 'Upload Safe Exam Browser config file';
 $string['seb_sebconfigfile_help'] = 'Please upload your own Safe Exam Browser config file for this quiz.';
 $string['seb_userconfirmquit'] = 'Ask user to confirm quitting';
 $string['seb_userconfirmquit_help'] = 'If enabled, users have to confirm quitting of SEB when a quit link is detected.';
-$string['seb_use_manually'] = 'Yes - Configure manually';
-$string['seb_use_template'] = 'Yes - Use an existing template';
-$string['seb_use_upload'] = 'Yes - Upload my own config';
-$string['seb_use_client'] = 'Yes - Use SEB client config';
+$string['seb_use_manually'] = 'Yes – Configure manually';
+$string['seb_use_template'] = 'Yes – Use an existing template';
+$string['seb_use_upload'] = 'Yes – Upload my own config';
+$string['seb_use_client'] = 'Yes – Use SEB client config';
 $string['disabledsettings'] = 'Disabled settings.';
 $string['disabledsettings_help'] = 'Safe Exam Browser quiz settings are unable to be updated if there is one or more existing quiz attempts. To re-enable settings, all quiz attempts must be deleted.';
 


### PR DESCRIPTION
I think we have a consent that carriage returns in the seb_requiresafeexambrowser_help text increase readability.
Additionnally I changed the never or extremely rarely used typographical “” to the standard "".

<img width="607" alt="grafik" src="https://user-images.githubusercontent.com/377279/72710576-b3a7a480-3b67-11ea-9805-9e681720a460.png">
