### PR TITLE
Issue #137 Display the Exit SEB button when attempts are present

### DIFF
--- a/classes/access_manager.php
+++ b/classes/access_manager.php
@@ -177,6 +177,15 @@ class access_manager {
     }
 
     /**
+     * Getter for the quiz_settings object.
+     *
+     * @return quiz_settings
+     */
+    public function get_quiz_settings() : quiz_settings {
+        return $this->quizsettings;
+    }
+
+    /**
      * Check the hash from the request header against the permitted browser exam keys.
      *
      * @param array $keys Allowed browser exam keys.

--- a/lang/en/quizaccess_seb.php
+++ b/lang/en/quizaccess_seb.php
@@ -187,6 +187,7 @@ $string['description'] = 'Description';
 $string['enabled'] = 'Enabled';
 $string['name'] = 'Name';
 $string['duplicatetemplate'] = "Template with the same name already exists";
+$string['exitsebbutton'] = 'Exit Safe Exam Browser';
 $string['invalidtemplate'] = "Invalid SEB config template";
 $string['cantdelete'] = 'Template can\'t be deleted as it has been used for one or more quizzes';
 $string['cantedit'] = 'Template can\'t be edited as it has been used for one or more quizzes';

--- a/rule.php
+++ b/rule.php
@@ -388,7 +388,7 @@ class quizaccess_seb extends quiz_access_rule_base {
 
         $output = $PAGE->get_renderer('mod_quiz');
         $quizsettings = $this->accessmanager->get_quiz_settings();
-        $attempts = quiz_get_user_attempts($quizsettings->get('quizid'), $USER->id, 'finished', true);
+        $attempts = quiz_get_user_attempts($quizsettings->get('quizid'), $USER->id, 'finished', false);
         $quitbutton = '';
 
         if (empty($attempts)) {
@@ -414,6 +414,8 @@ class quizaccess_seb extends quiz_access_rule_base {
      */
     public function description() {
         $messages = [get_string('sebrequired', 'quizaccess_seb')];
+
+        // Those with higher level access will be able to see the button if they've made an attempt.
         if (!$this->prevent_access()) {
             $messages[] = $this->display_quit_button();
         }

--- a/rule.php
+++ b/rule.php
@@ -384,9 +384,8 @@ class quizaccess_seb extends quiz_access_rule_base {
      * @return string empty or a button which has the configured seb quit link.
      */
     private function display_quit_button() : string {
-        global $PAGE, $USER;
+        global $OUTPUT, $USER;
 
-        $output = $PAGE->get_renderer('mod_quiz');
         $quizsettings = $this->accessmanager->get_quiz_settings();
         $attempts = quiz_get_user_attempts($quizsettings->get('quizid'), $USER->id, 'finished', false);
         $quitbutton = '';
@@ -398,7 +397,7 @@ class quizaccess_seb extends quiz_access_rule_base {
         // Only display if the link has been configured and attempts are greater than 0.
         if ($quizsettings->get('linkquitseb')) {
             $url = new moodle_url($quizsettings->get('linkquitseb'));
-            $quitbutton = $output->start_attempt_button(get_string('exitsebbutton', 'quizaccess_seb'), $url);
+            $quitbutton = $OUTPUT->single_button($url, get_string('exitsebbutton', 'quizaccess_seb'), 'get');
         }
 
         return $quitbutton;

--- a/tests/phpunit/rule_test.php
+++ b/tests/phpunit/rule_test.php
@@ -313,4 +313,95 @@ class quizaccess_seb_rule_testcase extends quizaccess_seb_testcase {
         $this->assertSame('', $method->invoke($rule));
     }
 
+    /**
+     * Test display_quit_button. If attempt count is greater than 0
+     */
+    public function test_display_quit_button() {
+        global $DB;
+
+        $user = $this->getDataGenerator()->create_user();
+        $course = $this->getDataGenerator()->create_course();
+        $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
+
+        // Set quiz setting to require seb.
+        $quizsettings = quiz_settings::get_record(['quizid' => $quiz->id]);
+        $quizsettings->set('requiresafeexambrowser', settings_provider::USE_SEB_CLIENT_CONFIG);
+        $quizsettings->set('linkquitseb', "http://test.quit.link");
+        $quizsettings->save();
+
+        // Set the user as display_quit_button() uses global $USER.
+        $this->setUser($user);
+
+        $quizparams = (object) [
+            'quiz' => $quiz->id,
+            'userid' => $user->id,
+            'state' => 'finished',
+            'timestart' => 100,
+            'timecheckstate' => 0,
+            'layout' => '',
+            'uniqueid' => 0
+        ];
+        // Insert a finished attempt into the database.
+        $attemptid = $DB->insert_record('quiz_attempts', $quizparams);
+
+        // Create the rule.
+        $rule = quizaccess_seb::make(new quiz($quiz, get_coursemodule_from_id('quiz', $quiz->cmid), $course), 0, true);
+
+        // Set-up the button to be called.
+        $reflection = new \ReflectionClass('quizaccess_seb');
+        $method = $reflection->getMethod('display_quit_button');
+        $method->setAccessible(true);
+
+        $button = $method->invoke($rule);
+        $this->assertContains("http://test.quit.link", $button);
+    }
+
+    /**
+     * Test description, checks for a valid SEB session and attempt count .
+     */
+    public function test_description() {
+        global $DB;
+
+        $user = $this->getDataGenerator()->create_user();
+        $course = $this->getDataGenerator()->create_course();
+        $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
+
+        // Set quiz setting to require seb.
+        $quizsettings = quiz_settings::get_record(['quizid' => $quiz->id]);
+        $quizsettings->set('requiresafeexambrowser', settings_provider::USE_SEB_CLIENT_CONFIG);
+        $quizsettings->set('linkquitseb', "http://test.quit.link");
+        $quizsettings->save();
+
+        // Set up basic dummy request.
+        $_SERVER['HTTP_USER_AGENT'] = 'SEB_TEST_SITE';
+
+        $quizparams = (object) [
+            'quiz' => $quiz->id,
+            'userid' => $user->id,
+            'state' => 'finished',
+            'timestart' => 100,
+            'timecheckstate' => 0,
+            'layout' => '',
+            'uniqueid' => 0
+        ];
+        // Insert a finished attempt into the database.
+        $attemptid = $DB->insert_record('quiz_attempts', $quizparams);
+
+        // Create the rule.
+        $rule = quizaccess_seb::make(new quiz($quiz, get_coursemodule_from_id('quiz', $quiz->cmid), $course), 0, true);
+
+        $description = $rule->description();
+        $this->assertCount(2, $description);
+        $this->assertEquals($description[0], get_string('sebrequired', 'quizaccess_seb'));
+        $this->assertEquals($description[1], '');
+
+        // Set the user as display_quit_button() uses the global $USER.
+        $this->setUser($user);
+        $description = $rule->description();
+        $this->assertCount(2, $description);
+        $this->assertEquals($description[0], get_string('sebrequired', 'quizaccess_seb'));
+
+        // The button is contained in the description when a quiz attempt is finished.
+        $this->assertContains("http://test.quit.link", $description[1]);
+    }
 }


### PR DESCRIPTION
By utilising the description() hook it is possible to render a button on the view.php page after an attempt has been created.

This can then provide the Exit SEB button.