### PR TITLE
Remove period to three settings labels.

### DIFF
--- a/lang/en/quizaccess_seb.php
+++ b/lang/en/quizaccess_seb.php
@@ -43,13 +43,13 @@ $string['quizsettings'] = 'Quiz settings';
 
 // Admin settings.
 $string['seb_managetemplates'] = 'Manage Safe Exam Browser templates';
-$string['setting:downloadlink'] = 'Safe Exam Browser download link.';
+$string['setting:downloadlink'] = 'Safe Exam Browser download link';
 $string['setting:downloadlink_desc'] = 'URL for downloading the Safe Exam Browser application.';
-$string['setting:quizpasswordrequired'] = 'Quiz password required.';
+$string['setting:quizpasswordrequired'] = 'Quiz password required';
 $string['setting:quizpasswordrequired_desc'] = 'Check this box if all quizzes that require the Safe Exam Browser must have a quiz password set.';
 $string['setting:showseblink'] = 'Show seb:// link';
 $string['setting:showhttplink'] = 'Show http:// link';
-$string['setting:showseblinks'] = 'Show Safe Exam Browser config links.';
+$string['setting:showseblinks'] = 'Show Safe Exam Browser config links';
 $string['setting:showseblinks_desc'] = 'Decide whether to show links for the user to access the Safe Exam Browser configuration file when access to quiz is prevented. Note that seb:// links may not work for every browser.';
 
 // Quiz form settings.


### PR DESCRIPTION
It's common not to add periods to those labels since they're not sentences.
Thanks.