### PR TITLE
Fixing .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-sudo: required
+os: linux
 
 addons:
   firefox: "47.0.1"
@@ -18,7 +18,7 @@ cache:
     - $HOME/.composer/cache
     - $HOME/.npm
 
-matrix:
+jobs:
   include:
     - php: 7.2
       env:


### PR DESCRIPTION
This omits the info/warnings

Build config validation
root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: missing os, using the default linux
root: key matrix is an alias for jobs, using jobs 

for the .travis.yml file.